### PR TITLE
Fix/param handling

### DIFF
--- a/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
+++ b/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
@@ -55,6 +55,7 @@ public:
 
 private:
   bool changeState(const std::string & node_name, std::uint8_t transition);
+  bool changeRobotCommandingState(bool is_active);
   void robotCommandingStateChanged(bool is_active);
   void getFRIState();
   lifecycle_msgs::msg::State getState(
@@ -73,6 +74,7 @@ private:
     reference_joint_state_publisher_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr robot_commanding_state_subscription_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr manage_processing_publisher_;
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr change_robot_manager_state_client_;
   rclcpp::Client<kuka_sunrise_interfaces::srv::GetState>::SharedPtr get_state_client_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr trigger_change_service_;
   rclcpp::CallbackGroup::SharedPtr cbg_;

--- a/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
+++ b/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
@@ -55,7 +55,6 @@ public:
 
 private:
   bool changeState(const std::string & node_name, std::uint8_t transition);
-  bool changeRobotCommandingState(bool is_active);
   void robotCommandingStateChanged(bool is_active);
   void getFRIState();
   lifecycle_msgs::msg::State getState(
@@ -74,7 +73,6 @@ private:
     reference_joint_state_publisher_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr robot_commanding_state_subscription_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr manage_processing_publisher_;
-  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr change_robot_manager_state_client_;
   rclcpp::Client<kuka_sunrise_interfaces::srv::GetState>::SharedPtr get_state_client_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr trigger_change_service_;
   rclcpp::CallbackGroup::SharedPtr cbg_;

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -148,13 +148,13 @@ SystemManager::on_activate(const rclcpp_lifecycle::State &)
 {
   auto result = SUCCESS;
   if (!changeState(
-      JOINT_CONTROLLER,
+      ROBOT_INTERFACE,
       lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
   {
     result = FAILURE;
   }
   if (result == SUCCESS && !changeState(
-      ROBOT_INTERFACE,
+      JOINT_CONTROLLER,
       lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
   {
     result = FAILURE;

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -144,13 +144,13 @@ SystemManager::on_activate(const rclcpp_lifecycle::State &)
 {
   auto result = SUCCESS;
   if (!changeState(
-      ROBOT_INTERFACE,
+      JOINT_CONTROLLER,
       lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
   {
     result = FAILURE;
   }
   if (result == SUCCESS && !changeState(
-      JOINT_CONTROLLER,
+      ROBOT_INTERFACE,
       lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
   {
     result = FAILURE;

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -30,6 +30,10 @@ SystemManager::SystemManager(
   qos_.reliable();
   cbg_ = this->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
+  change_robot_manager_state_client_ = this->create_client<
+    std_srvs::srv::SetBool>(
+    ROBOT_INTERFACE + "/set_commanding_state",
+    qos_.get_rmw_qos_profile(), cbg_);
   robot_commanding_state_subscription_ = this->create_subscription<
     std_msgs::msg::Bool>(
     ROBOT_INTERFACE + "/commanding_state_changed", qos_,
@@ -155,7 +159,9 @@ SystemManager::on_activate(const rclcpp_lifecycle::State &)
   {
     result = FAILURE;
   }
-
+  if (result == SUCCESS && !robot_control_active_ && !changeRobotCommandingState(true)) {
+    result = FAILURE;
+  }
   if (control_logic_ && result == SUCCESS &&
     !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
   {
@@ -178,6 +184,11 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn System
 on_deactivate(
   const rclcpp_lifecycle::State &)
 {
+  if (robot_control_active_ && !changeRobotCommandingState(false)) {
+    return ERROR;
+  }
+  robot_control_active_ = false;
+  if (polling_thread_.joinable()) {polling_thread_.join();}
   if (getState(ROBOT_INTERFACE).id != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
     !changeState(
       ROBOT_INTERFACE,
@@ -185,7 +196,6 @@ on_deactivate(
   {
     return ERROR;
   }
-  robot_control_active_ = false;
   if (getState(JOINT_CONTROLLER).id != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
     !changeState(
       JOINT_CONTROLLER,
@@ -200,7 +210,6 @@ on_deactivate(
   {
     return ERROR;
   }
-  if (polling_thread_.joinable()) {polling_thread_.join();}
 
   return SUCCESS;
 }
@@ -331,6 +340,23 @@ void SystemManager::getFRIState()
   auto future_result = get_state_client_->async_send_request(
     request,
     response_received_callback);
+}
+
+// Activate the ActivatableInterface of robot_manager_node
+bool SystemManager::changeRobotCommandingState(bool is_active)
+{
+  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
+  request->data = is_active;
+
+  auto response = kuka_sunrise::sendRequest<std_srvs::srv::SetBool::Response>(
+    change_robot_manager_state_client_, request, 2000, 1000);
+
+  if (!response || !response->success) {
+    RCLCPP_ERROR(get_logger(), "Could not change robot commanding state");
+    return false;
+  }
+  robot_control_active_ = true;
+  return true;
 }
 
 void SystemManager::robotCommandingStateChanged(bool is_active)

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -255,7 +255,6 @@ SystemManager::on_shutdown(const rclcpp_lifecycle::State & state)
     return FAILURE;
   }
 
-
   return result;
 }
 

--- a/kuka_sunrise_driver/CMakeLists.txt
+++ b/kuka_sunrise_driver/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(kuka_sunrise_interfaces REQUIRED)
+find_package(kroshu_ros2_core REQUIRED)
 
 include_directories(include)
 
@@ -70,19 +71,19 @@ ament_target_dependencies(robot_control_client kuka_sunrise_interfaces rclcpp rc
 
 add_library(configuration_manager SHARED
   src/kuka_sunrise/configuration_manager.cpp)
-ament_target_dependencies(configuration_manager kuka_sunrise_interfaces rclcpp rclcpp_lifecycle std_msgs std_srvs)
+ament_target_dependencies(configuration_manager kuka_sunrise_interfaces rclcpp rclcpp_lifecycle std_msgs std_srvs kroshu_ros2_core)
 
 
 add_executable(robot_manager_node
   src/kuka_sunrise/robot_manager_node.cpp)
-ament_target_dependencies(robot_manager_node kuka_sunrise_interfaces rclcpp rclcpp_lifecycle)
+ament_target_dependencies(robot_manager_node kuka_sunrise_interfaces rclcpp rclcpp_lifecycle kroshu_ros2_core)
 target_link_libraries(robot_manager_node
   robot_manager
   configuration_manager)
 
 add_executable(robot_control_node
   src/kuka_sunrise/robot_control_node.cpp)
-ament_target_dependencies(robot_control_node kuka_sunrise_interfaces rclcpp rclcpp_lifecycle std_msgs sensor_msgs std_srvs)
+ament_target_dependencies(robot_control_node kuka_sunrise_interfaces rclcpp rclcpp_lifecycle std_msgs sensor_msgs std_srvs kroshu_ros2_core)
 target_link_libraries(robot_control_node
   robot_control_client
   ${fri_client_library})

--- a/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
@@ -42,6 +42,7 @@ public:
     std::shared_ptr<RobotManager> robot_manager);
 
 private:
+  bool configured_ = false;
   std::shared_ptr<kroshu_ros2_core::ROS2BaseLCNode> robot_manager_node_;
   std::shared_ptr<RobotManager> robot_manager_;
   rclcpp::CallbackGroup::SharedPtr cbg_;
@@ -53,8 +54,8 @@ private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr set_parameter_service_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
 
-  std::vector<double> joint_stiffness_temp_ = std::vector<double>(7, 1000.0);
-  std::vector<double> joint_damping_temp_ =std::vector<double>(7, 0.7);
+  std::vector<double> joint_stiffness_ = std::vector<double>(7, 1000.0);
+  std::vector<double> joint_damping_ =std::vector<double>(7, 0.7);
 
   bool onCommandModeChangeRequest(const std::string & command_mode);
   bool onControlModeChangeRequest(const std::string & control_mode);
@@ -62,11 +63,11 @@ private:
   bool onJointDampingChangeRequest(const std::vector<double> & joint_damping);
   bool onSendPeriodChangeRequest(const int & send_period);
   bool onReceiveMultiplierChangeRequest(const int & receive_multiplier);
-  bool onControllerIpChangeRequest(const std::string & controller_i);
+  bool onControllerIpChangeRequest(const std::string & controller_ip);
   bool setCommandMode(const std::string & control_mode) const;
   bool setReceiveMultiplier(int receive_multiplier) const;
   bool setSendPeriod(int send_period) const;
-  void setParameters();
+  void setParameters(std_srvs::srv::Trigger::Response::SharedPtr response);
 };
 }  // namespace kuka_sunrise
 

--- a/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
@@ -57,13 +57,13 @@ private:
   std::vector<double> joint_stiffness_ = std::vector<double>(7, 1000.0);
   std::vector<double> joint_damping_ = std::vector<double>(7, 0.7);
 
-  bool onCommandModeChangeRequest(const std::string & command_mode);
-  bool onControlModeChangeRequest(const std::string & control_mode);
+  bool onCommandModeChangeRequest(const std::string & command_mode) const;
+  bool onControlModeChangeRequest(const std::string & control_mode) const;
   bool onJointStiffnessChangeRequest(const std::vector<double> & joint_stiffness);
   bool onJointDampingChangeRequest(const std::vector<double> & joint_damping);
-  bool onSendPeriodChangeRequest(const int & send_period);
-  bool onReceiveMultiplierChangeRequest(const int & receive_multiplier);
-  bool onControllerIpChangeRequest(const std::string & controller_ip);
+  bool onSendPeriodChangeRequest(const int & send_period) const;
+  bool onReceiveMultiplierChangeRequest(const int & receive_multiplier) const;
+  bool onControllerIpChangeRequest(const std::string & controller_ip) const;
   bool setCommandMode(const std::string & control_mode) const;
   bool setReceiveMultiplier(int receive_multiplier) const;
   bool setSendPeriod(int send_period) const;

--- a/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
@@ -55,7 +55,7 @@ private:
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
 
   std::vector<double> joint_stiffness_ = std::vector<double>(7, 1000.0);
-  std::vector<double> joint_damping_ =std::vector<double>(7, 0.7);
+  std::vector<double> joint_damping_ = std::vector<double>(7, 0.7);
 
   bool onCommandModeChangeRequest(const std::string & command_mode);
   bool onControlModeChangeRequest(const std::string & control_mode);

--- a/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
@@ -34,32 +34,6 @@ namespace kuka_sunrise
 
 class RobotManager;
 
-struct ParameterSetAccessRights
-{
-  bool unconfigured;
-  bool inactive;
-  bool active;
-  bool finalized;
-  bool configuring;
-  bool isSetAllowed(std::uint8_t current_state)
-  {
-    switch (current_state) {
-      case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
-        return unconfigured;
-      case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
-        return inactive;
-      case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
-        return active;
-      case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
-        return finalized;
-      case lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING:
-        return configuring;
-      default:
-        return false;
-    }
-  }
-};
-
 class ConfigurationManager
 {
 public:
@@ -77,13 +51,12 @@ private:
   rclcpp::Client<kuka_sunrise_interfaces::srv::SetInt>::SharedPtr sync_receive_multiplier_client_;
   rclcpp::Client<kuka_sunrise_interfaces::srv::SetInt>::SharedPtr sync_send_period_client_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr set_parameter_service_;
-  std::map<std::string, struct ParameterSetAccessRights> parameter_set_access_rights_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
 
   std::shared_ptr<kroshu_ros2_core::ROS2BaseLCNode> base_ptr_;
 
-  std::vector<double> joint_stiffness_temp_;
-  std::vector<double> joint_damping_temp_;
+  std::vector<double> joint_stiffness_temp_ = std::vector<double>(7, 1000.0);
+  std::vector<double> joint_damping_temp_ =std::vector<double>(7, 0.7);
 
   bool onCommandModeChangeRequest(const std::string & command_mode);
   bool onControlModeChangeRequest(const std::string & control_mode);
@@ -92,9 +65,9 @@ private:
   bool onSendPeriodChangeRequest(const int & send_period);
   bool onReceiveMultiplierChangeRequest(const int & receive_multiplier);
   bool onControllerIpChangeRequest(const std::string & controller_i);
-  bool setCommandMode(const std::string & control_mode);
-  bool setReceiveMultiplier(int receive_multiplier);
-  bool setSendPeriod(int send_period);
+  bool setCommandMode(const std::string & control_mode) const;
+  bool setReceiveMultiplier(int receive_multiplier) const;
+  bool setSendPeriod(int send_period) const;
   void setParameters();
 };
 }  // namespace kuka_sunrise

--- a/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
@@ -27,6 +27,8 @@
 #include "std_srvs/srv/trigger.hpp"
 #include "kuka_sunrise_interfaces/srv/set_int.hpp"
 
+#include "kroshu_ros2_core/ROS2BaseLCNode.hpp"
+
 namespace kuka_sunrise
 {
 
@@ -62,11 +64,11 @@ class ConfigurationManager
 {
 public:
   ConfigurationManager(
-    rclcpp_lifecycle::LifecycleNode::SharedPtr robot_manager_node,
+    kroshu_ros2_core::ROS2BaseLCNode::SharedPtr robot_manager_node,
     std::shared_ptr<RobotManager> robot_manager);
 
 private:
-  rclcpp_lifecycle::LifecycleNode::SharedPtr robot_manager_node_;
+  kroshu_ros2_core::ROS2BaseLCNode::SharedPtr robot_manager_node_;
   std::shared_ptr<RobotManager> robot_manager_;
   rclcpp::CallbackGroup::SharedPtr cbg_;
   rclcpp::CallbackGroup::SharedPtr param_cbg_;
@@ -78,24 +80,23 @@ private:
   std::map<std::string, struct ParameterSetAccessRights> parameter_set_access_rights_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
 
+  std::shared_ptr<kroshu_ros2_core::ROS2BaseLCNode> base_ptr_;
+
   std::vector<double> joint_stiffness_temp_;
   std::vector<double> joint_damping_temp_;
 
-  rcl_interfaces::msg::SetParametersResult onParamChange(
-    const std::vector<rclcpp::Parameter> & parameters);
-  bool canSetParameter(const rclcpp::Parameter & param);
-  bool onCommandModeChangeRequest(const rclcpp::Parameter & param);
-  bool onControlModeChangeRequest(const rclcpp::Parameter & param);
-  bool onJointStiffnessChangeRequest(const rclcpp::Parameter & param);
-  bool onJointDampingChangeRequest(const rclcpp::Parameter & param);
-  bool onSendPeriodChangeRequest(const rclcpp::Parameter & param);
-  bool onReceiveMultiplierChangeRequest(const rclcpp::Parameter & param);
-  bool onControllerIpChangeRequest(const rclcpp::Parameter & param);
+  bool onCommandModeChangeRequest(const std::string & command_mode);
+  bool onControlModeChangeRequest(const std::string & control_mode);
+  bool onJointStiffnessChangeRequest(const std::vector<double> & joint_stiffness);
+  bool onJointDampingChangeRequest(const std::vector<double> & joint_damping);
+  bool onSendPeriodChangeRequest(const int & send_period);
+  bool onReceiveMultiplierChangeRequest(const int & receive_multiplier);
+  bool onControllerIpChangeRequest(const std::string & controller_i);
   bool setCommandMode(const std::string & control_mode);
   bool setReceiveMultiplier(int receive_multiplier);
   bool setSendPeriod(int send_period);
+  void setParameters();
 };
-
 }  // namespace kuka_sunrise
 
 #endif  // KUKA_SUNRISE__CONFIGURATION_MANAGER_HPP_

--- a/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/configuration_manager.hpp
@@ -38,11 +38,11 @@ class ConfigurationManager
 {
 public:
   ConfigurationManager(
-    kroshu_ros2_core::ROS2BaseLCNode::SharedPtr robot_manager_node,
+    std::shared_ptr<kroshu_ros2_core::ROS2BaseLCNode> robot_manager_node,
     std::shared_ptr<RobotManager> robot_manager);
 
 private:
-  kroshu_ros2_core::ROS2BaseLCNode::SharedPtr robot_manager_node_;
+  std::shared_ptr<kroshu_ros2_core::ROS2BaseLCNode> robot_manager_node_;
   std::shared_ptr<RobotManager> robot_manager_;
   rclcpp::CallbackGroup::SharedPtr cbg_;
   rclcpp::CallbackGroup::SharedPtr param_cbg_;
@@ -52,8 +52,6 @@ private:
   rclcpp::Client<kuka_sunrise_interfaces::srv::SetInt>::SharedPtr sync_send_period_client_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr set_parameter_service_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
-
-  std::shared_ptr<kroshu_ros2_core::ROS2BaseLCNode> base_ptr_;
 
   std::vector<double> joint_stiffness_temp_ = std::vector<double>(7, 1000.0);
   std::vector<double> joint_damping_temp_ =std::vector<double>(7, 0.7);

--- a/kuka_sunrise_driver/include/kuka_sunrise/robot_control_node.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/robot_control_node.hpp
@@ -22,7 +22,6 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "std_srvs/srv/set_bool.hpp"
 
 #include "fri_client/friClientApplication.h"
@@ -31,11 +30,12 @@
 #include "kuka_sunrise/internal/activatable_interface.hpp"
 #include "kuka_sunrise_interfaces/srv/get_state.hpp"
 
+#include "kroshu_ros2_core/ROS2BaseLCNode.hpp"
 
 namespace kuka_sunrise
 {
 
-class RobotControlNode : public rclcpp_lifecycle::LifecycleNode, public ActivatableInterface
+class RobotControlNode : public kroshu_ros2_core::ROS2BaseLCNode, public ActivatableInterface
 {
 public:
   RobotControlNode();
@@ -73,13 +73,6 @@ private:
   rclcpp::CallbackGroup::SharedPtr cbg_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr change_robot_control_state_service_;
   rclcpp::Service<kuka_sunrise_interfaces::srv::GetState>::SharedPtr get_fri_state_service_;
-
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SUCCESS =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn ERROR =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn FAILURE =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
 };
 
 }  // namespace kuka_sunrise

--- a/kuka_sunrise_driver/include/kuka_sunrise/robot_control_node.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/robot_control_node.hpp
@@ -39,7 +39,6 @@ class RobotControlNode : public kroshu_ros2_core::ROS2BaseLCNode, public Activat
 {
 public:
   RobotControlNode();
-  ~RobotControlNode();
   void runClientApplication();
 
   virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
@@ -49,16 +48,10 @@ public:
   on_cleanup(const rclcpp_lifecycle::State &);
 
   virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_shutdown(const rclcpp_lifecycle::State &);
-
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_activate(const rclcpp_lifecycle::State &);
 
   virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_deactivate(const rclcpp_lifecycle::State &);
-
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_error(const rclcpp_lifecycle::State &);
 
   virtual bool activate();
   virtual bool deactivate();

--- a/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
@@ -20,7 +20,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/client.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/srv/change_state.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "std_srvs/srv/set_bool.hpp"
@@ -31,11 +30,12 @@
 #include "kuka_sunrise/configuration_manager.hpp"
 #include "kuka_sunrise/internal/activatable_interface.hpp"
 
+#include "kroshu_ros2_core/ROS2BaseLCNode.hpp"
 
 namespace kuka_sunrise
 {
 
-class RobotManagerNode : public rclcpp_lifecycle::LifecycleNode, public ActivatableInterface
+class RobotManagerNode : public kroshu_ros2_core::ROS2BaseLCNode, public ActivatableInterface
 {
 public:
   RobotManagerNode();
@@ -76,13 +76,6 @@ private:
   void handleControlEndedError();
   void handleFRIEndedError();
   rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr set_command_state_client_;
-
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SUCCESS =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn ERROR =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn FAILURE =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
 };
 
 }  // namespace kuka_sunrise

--- a/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
@@ -67,6 +67,7 @@ private:
   rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr change_robot_control_state_client_;
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr set_parameter_client_;
   rclcpp::CallbackGroup::SharedPtr cbg_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr change_robot_manager_state_service_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
     command_state_changed_publisher_;
 

--- a/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
@@ -55,9 +55,6 @@ public:
   virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_deactivate(const rclcpp_lifecycle::State &);
 
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_error(const rclcpp_lifecycle::State &);
-
   bool activate();
   bool deactivate();
 

--- a/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/robot_manager_node.hpp
@@ -67,7 +67,6 @@ private:
   rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr change_robot_control_state_client_;
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr set_parameter_client_;
   rclcpp::CallbackGroup::SharedPtr cbg_;
-  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr change_robot_manager_state_service_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
     command_state_changed_publisher_;
 

--- a/kuka_sunrise_driver/package.xml
+++ b/kuka_sunrise_driver/package.xml
@@ -18,6 +18,7 @@
 	<build_depend>std_srvs</build_depend>
 	<build_depend>sensor_msgs</build_depend>
 	<build_depend>kuka_sunrise_interfaces</build_depend>
+	<build_depend>kroshu_ros2_core</build_depend>
 
 	<exec_depend>rclcpp</exec_depend>
 	<exec_depend>rclcpp_lifecycle</exec_depend>

--- a/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
@@ -67,7 +67,7 @@ ConfigurationManager::ConfigurationManager(
     }, ::rmw_qos_profile_default, param_cbg_);
 }
 
-bool ConfigurationManager::onCommandModeChangeRequest(const std::string & command_mode)
+bool ConfigurationManager::onCommandModeChangeRequest(const std::string & command_mode) const
 {
   if (command_mode == "position") {
     if (!setCommandMode("position")) {
@@ -98,7 +98,7 @@ bool ConfigurationManager::onCommandModeChangeRequest(const std::string & comman
   return true;
 }
 
-bool ConfigurationManager::onControlModeChangeRequest(const std::string & control_mode)
+bool ConfigurationManager::onControlModeChangeRequest(const std::string & control_mode) const
 {
   if (control_mode == "position") {
     return robot_manager_->setPositionControlMode();
@@ -156,7 +156,7 @@ bool ConfigurationManager::onJointDampingChangeRequest(const std::vector<double>
   return true;
 }
 
-bool ConfigurationManager::onSendPeriodChangeRequest(const int & send_period)
+bool ConfigurationManager::onSendPeriodChangeRequest(const int & send_period) const
 {
   if (send_period < 1 || send_period > 100) {
     RCLCPP_ERROR(
@@ -170,7 +170,7 @@ bool ConfigurationManager::onSendPeriodChangeRequest(const int & send_period)
   return true;
 }
 
-bool ConfigurationManager::onReceiveMultiplierChangeRequest(const int & receive_multiplier)
+bool ConfigurationManager::onReceiveMultiplierChangeRequest(const int & receive_multiplier) const
 {
   if (receive_multiplier < 1) {
     RCLCPP_ERROR(robot_manager_node_->get_logger(), "Receive multiplier must be >=1");
@@ -182,7 +182,7 @@ bool ConfigurationManager::onReceiveMultiplierChangeRequest(const int & receive_
   return true;
 }
 
-bool ConfigurationManager::onControllerIpChangeRequest(const std::string & controller_ip)
+bool ConfigurationManager::onControllerIpChangeRequest(const std::string & controller_ip) const
 {
   // Check IP validity
   size_t i = 0;
@@ -200,7 +200,7 @@ bool ConfigurationManager::onControllerIpChangeRequest(const std::string & contr
     return false;
   }
 
-  for (auto & ip : split_ip) {
+  for (const auto & ip : split_ip) {
     if (ip.empty() || (ip.find_first_not_of("[0123456789]") != std::string::npos) ||
       stoi(ip) > 255 || stoi(ip) < 0)
     {

--- a/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
@@ -23,14 +23,13 @@
 namespace kuka_sunrise
 {
 ConfigurationManager::ConfigurationManager(
-  kroshu_ros2_core::ROS2BaseLCNode::SharedPtr robot_manager_node,
+  std::shared_ptr<kroshu_ros2_core::ROS2BaseLCNode> robot_manager_node,
   std::shared_ptr<RobotManager> robot_manager)
 : robot_manager_node_(robot_manager_node), robot_manager_(robot_manager)
 {
-  base_ptr_ = std::dynamic_pointer_cast<kroshu_ros2_core::ROS2BaseLCNode>(robot_manager_node);
   param_callback_ = robot_manager_node_->add_on_set_parameters_callback(
     [this](const std::vector<rclcpp::Parameter> & parameters) {
-      return base_ptr_->getParameterHandler().onParamChange(parameters);
+      return robot_manager_node_->getParameterHandler().onParamChange(parameters);
     });
 
   auto qos = rclcpp::QoS(rclcpp::KeepLast(10));
@@ -54,7 +53,7 @@ ConfigurationManager::ConfigurationManager(
     "sync_send_period", qos.get_rmw_qos_profile(),
     cbg_);
 
-  base_ptr_->registerParameter<std::string>(
+  robot_manager_node_->registerParameter<std::string>(
     "controller_ip", "", kroshu_ros2_core::ParameterSetAccessRights {false, false,
       false, false, true}, [this](const std::string & controller_ip) {
       return this->onControllerIpChangeRequest(controller_ip);
@@ -291,37 +290,37 @@ bool ConfigurationManager::setSendPeriod(int send_period) const
 void ConfigurationManager::setParameters()
 {
   // TODO(Svastits): wait for results
-  base_ptr_->registerParameter<std::string>(
+  robot_manager_node_->registerParameter<std::string>(
     "control_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
       false, true}, [this](const std::string & control_mode) {
       return this->onControlModeChangeRequest(control_mode);
     });
 
-  base_ptr_->registerParameter<std::string>(
+  robot_manager_node_->registerParameter<std::string>(
     "command_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
       false, true}, [this](const std::string & command_mode) {
       return this->onCommandModeChangeRequest(command_mode);
     });
 
-  base_ptr_->registerParameter<int>(
+  robot_manager_node_->registerParameter<int>(
     "receive_multiplier", 1, kroshu_ros2_core::ParameterSetAccessRights {false, true, false, false,
       true}, [this](const int & receive_multiplier) {
       return this->onReceiveMultiplierChangeRequest(receive_multiplier);
     });
 
-  base_ptr_->registerParameter<int>(
+  robot_manager_node_->registerParameter<int>(
     "send_period_ms", 10, kroshu_ros2_core::ParameterSetAccessRights {false, true, false, false,
       true}, [this](const int & send_period) {
       return this->onSendPeriodChangeRequest(send_period);
     });
 
-  base_ptr_->registerParameter<std::vector<double>>(
+  robot_manager_node_->registerParameter<std::vector<double>>(
     "joint_stiffness", joint_stiffness_temp_, kroshu_ros2_core::ParameterSetAccessRights {false,
       true, true, false, true}, [this](const std::vector<double> & joint_stiffness) {
       return this->onJointStiffnessChangeRequest(joint_stiffness);
     });
 
-  base_ptr_->registerParameter<std::vector<double>>(
+  robot_manager_node_->registerParameter<std::vector<double>>(
     "joint_damping", joint_damping_temp_, kroshu_ros2_core::ParameterSetAccessRights {false, true,
       true, false, true}, [this](const std::vector<double> & joint_damping) {
       return this->onJointDampingChangeRequest(joint_damping);

--- a/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
@@ -63,7 +63,7 @@ ConfigurationManager::ConfigurationManager(
     "configuration_manager/set_params", [this](
       std_srvs::srv::Trigger::Request::SharedPtr,
       std_srvs::srv::Trigger::Response::SharedPtr response) {
-      this->setParameters(std_srvs::srv::Trigger::Response::SharedPtr response);
+      this->setParameters(response);
     }, ::rmw_qos_profile_default, param_cbg_);
 }
 

--- a/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
@@ -116,7 +116,6 @@ bool ConfigurationManager::onControlModeChangeRequest(const std::string & contro
       robot_manager_node_->get_logger(), "Control mode should be 'position' or 'joint_impedance'");
     return false;
   }
-  return true;
 }
 
 bool ConfigurationManager::onJointStiffnessChangeRequest(

--- a/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
@@ -202,7 +202,7 @@ bool ConfigurationManager::onControllerIpChangeRequest(const std::string & contr
   }
 
   for (auto & ip : split_ip) {
-    if (ip.empty() || (ip.find_first_not_of("[0123456789]") == std::string::npos) ||
+    if (ip.empty() || (ip.find_first_not_of("[0123456789]") != std::string::npos) ||
       stoi(ip) > 255 || stoi(ip) < 0)
     {
       RCLCPP_ERROR(
@@ -294,44 +294,49 @@ void ConfigurationManager::setParameters(std_srvs::srv::Trigger::Response::Share
     response->success = true;
     return;
   }
-  // TODO(Svastits): wait for results
-  robot_manager_node_->registerParameter<std::string>(
-    "control_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
-      false, true}, [this](const std::string & control_mode) {
-      return this->onControlModeChangeRequest(control_mode);
-    });
+  try {
+    // TODO(Svastits): wait for results
+    robot_manager_node_->registerParameter<std::string>(
+      "control_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
+        false, true}, [this](const std::string & control_mode) {
+        return this->onControlModeChangeRequest(control_mode);
+      });
 
-  robot_manager_node_->registerParameter<std::string>(
-    "command_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
-      false, true}, [this](const std::string & command_mode) {
-      return this->onCommandModeChangeRequest(command_mode);
-    });
+    robot_manager_node_->registerParameter<std::string>(
+      "command_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
+        false, true}, [this](const std::string & command_mode) {
+        return this->onCommandModeChangeRequest(command_mode);
+      });
 
-  robot_manager_node_->registerParameter<int>(
-    "receive_multiplier", 1, kroshu_ros2_core::ParameterSetAccessRights {false, true, false, false,
-      true}, [this](const int & receive_multiplier) {
-      return this->onReceiveMultiplierChangeRequest(receive_multiplier);
-    });
+    robot_manager_node_->registerParameter<int>(
+      "receive_multiplier", 1, kroshu_ros2_core::ParameterSetAccessRights {false, true, false,
+        false,
+        true}, [this](const int & receive_multiplier) {
+        return this->onReceiveMultiplierChangeRequest(receive_multiplier);
+      });
 
-  robot_manager_node_->registerParameter<int>(
-    "send_period_ms", 10, kroshu_ros2_core::ParameterSetAccessRights {false, true, false, false,
-      true}, [this](const int & send_period) {
-      return this->onSendPeriodChangeRequest(send_period);
-    });
+    robot_manager_node_->registerParameter<int>(
+      "send_period_ms", 10, kroshu_ros2_core::ParameterSetAccessRights {false, true, false, false,
+        true}, [this](const int & send_period) {
+        return this->onSendPeriodChangeRequest(send_period);
+      });
 
-  robot_manager_node_->registerParameter<std::vector<double>>(
-    "joint_stiffness", joint_stiffness_, kroshu_ros2_core::ParameterSetAccessRights {false,
-      true, true, false, true}, [this](const std::vector<double> & joint_stiffness) {
-      return this->onJointStiffnessChangeRequest(joint_stiffness);
-    });
+    robot_manager_node_->registerParameter<std::vector<double>>(
+      "joint_stiffness", joint_stiffness_, kroshu_ros2_core::ParameterSetAccessRights {false,
+        true, true, false, true}, [this](const std::vector<double> & joint_stiffness) {
+        return this->onJointStiffnessChangeRequest(joint_stiffness);
+      });
 
-  robot_manager_node_->registerParameter<std::vector<double>>(
-    "joint_damping", joint_damping_, kroshu_ros2_core::ParameterSetAccessRights {false, true,
-      true, false, true}, [this](const std::vector<double> & joint_damping) {
-      return this->onJointDampingChangeRequest(joint_damping);
-    });
+    robot_manager_node_->registerParameter<std::vector<double>>(
+      "joint_damping", joint_damping_, kroshu_ros2_core::ParameterSetAccessRights {false, true,
+        true, false, true}, [this](const std::vector<double> & joint_damping) {
+        return this->onJointDampingChangeRequest(joint_damping);
+      });
 
-  configured_ = true;
-  response->success = true;
+    configured_ = true;
+    response->success = true;
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(robot_manager_node_->get_logger(), "Parameterchange not success");
+  }
 }
 }  // namespace kuka_sunrise

--- a/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/configuration_manager.cpp
@@ -294,49 +294,49 @@ void ConfigurationManager::setParameters(std_srvs::srv::Trigger::Response::Share
     response->success = true;
     return;
   }
-  try {
-    // TODO(Svastits): wait for results
-    robot_manager_node_->registerParameter<std::string>(
-      "control_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
-        false, true}, [this](const std::string & control_mode) {
-        return this->onControlModeChangeRequest(control_mode);
-      });
+  // The parameter callbacks are called on this thread
+  // Response is sent only after all parameters are declared (or error occurs)
+  // Parameter exceptions are intentionally not caught, because in case of an invalid
+  //   parameter type (or value), the nodes must be launched again with changed parameters
+  //   because they could not be declared, therefore change is not possible in runtime
+  robot_manager_node_->registerParameter<std::string>(
+    "control_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
+      false, true}, [this](const std::string & control_mode) {
+      return this->onControlModeChangeRequest(control_mode);
+    });
 
-    robot_manager_node_->registerParameter<std::string>(
-      "command_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
-        false, true}, [this](const std::string & command_mode) {
-        return this->onCommandModeChangeRequest(command_mode);
-      });
+  robot_manager_node_->registerParameter<std::string>(
+    "command_mode", "position", kroshu_ros2_core::ParameterSetAccessRights {false, true, true,
+      false, true}, [this](const std::string & command_mode) {
+      return this->onCommandModeChangeRequest(command_mode);
+    });
 
-    robot_manager_node_->registerParameter<int>(
-      "receive_multiplier", 1, kroshu_ros2_core::ParameterSetAccessRights {false, true, false,
-        false,
-        true}, [this](const int & receive_multiplier) {
-        return this->onReceiveMultiplierChangeRequest(receive_multiplier);
-      });
+  robot_manager_node_->registerParameter<int>(
+    "receive_multiplier", 1, kroshu_ros2_core::ParameterSetAccessRights {false, true, false,
+      false,
+      true}, [this](const int & receive_multiplier) {
+      return this->onReceiveMultiplierChangeRequest(receive_multiplier);
+    });
 
-    robot_manager_node_->registerParameter<int>(
-      "send_period_ms", 10, kroshu_ros2_core::ParameterSetAccessRights {false, true, false, false,
-        true}, [this](const int & send_period) {
-        return this->onSendPeriodChangeRequest(send_period);
-      });
+  robot_manager_node_->registerParameter<int>(
+    "send_period_ms", 10, kroshu_ros2_core::ParameterSetAccessRights {false, true, false, false,
+      true}, [this](const int & send_period) {
+      return this->onSendPeriodChangeRequest(send_period);
+    });
 
-    robot_manager_node_->registerParameter<std::vector<double>>(
-      "joint_stiffness", joint_stiffness_, kroshu_ros2_core::ParameterSetAccessRights {false,
-        true, true, false, true}, [this](const std::vector<double> & joint_stiffness) {
-        return this->onJointStiffnessChangeRequest(joint_stiffness);
-      });
+  robot_manager_node_->registerParameter<std::vector<double>>(
+    "joint_stiffness", joint_stiffness_, kroshu_ros2_core::ParameterSetAccessRights {false,
+      true, true, false, true}, [this](const std::vector<double> & joint_stiffness) {
+      return this->onJointStiffnessChangeRequest(joint_stiffness);
+    });
 
-    robot_manager_node_->registerParameter<std::vector<double>>(
-      "joint_damping", joint_damping_, kroshu_ros2_core::ParameterSetAccessRights {false, true,
-        true, false, true}, [this](const std::vector<double> & joint_damping) {
-        return this->onJointDampingChangeRequest(joint_damping);
-      });
+  robot_manager_node_->registerParameter<std::vector<double>>(
+    "joint_damping", joint_damping_, kroshu_ros2_core::ParameterSetAccessRights {false, true,
+      true, false, true}, [this](const std::vector<double> & joint_damping) {
+      return this->onJointDampingChangeRequest(joint_damping);
+    });
 
-    configured_ = true;
-    response->success = true;
-  } catch (const std::exception & e) {
-    RCLCPP_WARN(robot_manager_node_->get_logger(), "Parameterchange not success");
-  }
+  configured_ = true;
+  response->success = true;
 }
 }  // namespace kuka_sunrise

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_control_client.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_control_client.cpp
@@ -49,6 +49,10 @@ RobotControlClient::~RobotControlClient()
 
 bool RobotControlClient::activate()
 {
+  // TODO(Svastits): activating the robot_observer should be moved to the on_activate function
+  //   of the node! As of now, activating the driver nodes in themselves do not activate
+  //   the observer, and the monitoring mode is not working on the ROS2 side
+  //   (the publisher is not active, joint states are not sent)
   this->ActivatableInterface::activate();
   robot_commander_->activate();
   robot_observer_->activate();

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_control_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_control_node.cpp
@@ -21,7 +21,7 @@ namespace kuka_sunrise
 {
 
 RobotControlNode::RobotControlNode()
-: LifecycleNode("robot_control"), close_requested_(false)
+: kroshu_ros2_core::ROS2BaseLCNode("robot_control"), close_requested_(false)
 {
   auto qos = rclcpp::QoS(rclcpp::KeepLast(1));
   qos.reliable();

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_control_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_control_node.cpp
@@ -49,11 +49,6 @@ RobotControlNode::RobotControlNode()
     "robot_control/get_fri_state", get_fri_state_callback);
 }
 
-RobotControlNode::~RobotControlNode()
-{
-  printf("in destructor");
-}
-
 void RobotControlNode::runClientApplication()
 {
   client_application_->connect(30200, NULL);
@@ -103,28 +98,6 @@ RobotControlNode::on_cleanup(const rclcpp_lifecycle::State &)
   return SUCCESS;
 }
 
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-RobotControlNode::on_shutdown(const rclcpp_lifecycle::State & state)
-{
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn result = SUCCESS;
-  switch (state.id()) {
-    case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
-      result = this->on_deactivate(get_current_state());
-      if (result != SUCCESS) {
-        break;
-      }
-      result = this->on_cleanup(get_current_state());
-      break;
-    case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
-      result = this->on_cleanup(get_current_state());
-      break;
-    case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
-      break;
-    default:
-      break;
-  }
-  return result;
-}
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 RobotControlNode::on_activate(const rclcpp_lifecycle::State &)
@@ -158,13 +131,6 @@ RobotControlNode::on_deactivate(const rclcpp_lifecycle::State &)
   client_application_->disconnect();
   client_application_.reset();
   client_application_thread_.reset();
-  return SUCCESS;
-}
-
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-RobotControlNode::on_error(const rclcpp_lifecycle::State &)
-{
-  RCLCPP_INFO(get_logger(), "An error occured");
   return SUCCESS;
 }
 

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -166,10 +166,10 @@ RobotManagerNode::on_activate(const rclcpp_lifecycle::State &)
     RCLCPP_ERROR(get_logger(), "Parameter send_period_ms or receive_multiplier not available");
     return FAILURE;
   }
-  rclcpp::Parameter send_period_ms = this->get_parameter("send_period_ms");
-  rclcpp::Parameter receive_multiplier = this->get_parameter("receive_multiplier");
+  int send_period_ms = this->get_parameter("send_period_ms").as_int();
+  int receive_multiplier = this->get_parameter("receive_multiplier").as_int();
 
-  if (!robot_manager_->setFRIConfig(30200, send_period_ms.as_int(), receive_multiplier.as_int())) {
+  if (!robot_manager_->setFRIConfig(30200, send_period_ms, receive_multiplier)) {
     RCLCPP_ERROR(get_logger(), "could not set fri config");
     return FAILURE;
   }

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -66,8 +66,8 @@ RobotManagerNode::on_configure(const rclcpp_lifecycle::State &)
 
   if (!configuration_manager_) {
     configuration_manager_ = std::make_unique<ConfigurationManager>(
-      this->shared_from_this(),
-      robot_manager_);
+      std::dynamic_pointer_cast<kroshu_ros2_core::ROS2BaseLCNode>(
+        this->shared_from_this()), robot_manager_);
   }
 
   if (!this->has_parameter("controller_ip")) {

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -218,13 +218,6 @@ RobotManagerNode::on_deactivate(const rclcpp_lifecycle::State &)
   return SUCCESS;
 }
 
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-RobotManagerNode::on_error(const rclcpp_lifecycle::State &)
-{
-  RCLCPP_ERROR(get_logger(), "An error occured");
-  return SUCCESS;
-}
-
 bool RobotManagerNode::activate()
 {
   this->ActivatableInterface::activate();

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -157,8 +157,8 @@ RobotManagerNode::on_activate(const rclcpp_lifecycle::State &)
     return ERROR;
   }
 
-  int send_period_ms = this->get_parameter("send_period_ms").as_int();
-  int receive_multiplier = this->get_parameter("receive_multiplier").as_int();
+  int send_period_ms = static_cast<int>(this->get_parameter("send_period_ms").as_int());
+  int receive_multiplier = static_cast<int>(this->get_parameter("receive_multiplier").as_int());
 
   if (!robot_manager_->setFRIConfig(30200, send_period_ms, receive_multiplier)) {
     RCLCPP_ERROR(get_logger(), "could not set fri config");

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -37,7 +37,17 @@ RobotManagerNode::RobotManagerNode()
     "robot_control/change_state", qos.get_rmw_qos_profile(), cbg_);
   set_command_state_client_ = this->create_client<std_srvs::srv::SetBool>(
     "robot_control/set_commanding_state", qos.get_rmw_qos_profile(), cbg_);
-
+  auto command_srv_callback = [this](
+    std_srvs::srv::SetBool::Request::SharedPtr request,
+    std_srvs::srv::SetBool::Response::SharedPtr response) {
+      if (request->data == true) {
+        response->success = this->activate();
+      } else {
+        response->success = this->deactivate();
+      }
+    };
+  change_robot_manager_state_service_ = this->create_service<std_srvs::srv::SetBool>(
+    "robot_manager/set_commanding_state", command_srv_callback);
   command_state_changed_publisher_ = this->create_publisher<std_msgs::msg::Bool>(
     "robot_manager/commanding_state_changed", qos);
   set_parameter_client_ = this->create_client<std_srvs::srv::Trigger>(
@@ -173,7 +183,6 @@ RobotManagerNode::on_activate(const rclcpp_lifecycle::State &)
   }
 
   command_state_changed_publisher_->on_activate();
-  if (!this->activate()) {return FAILURE;}
 
   return SUCCESS;
 }
@@ -181,7 +190,6 @@ RobotManagerNode::on_activate(const rclcpp_lifecycle::State &)
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 RobotManagerNode::on_deactivate(const rclcpp_lifecycle::State &)
 {
-  if (!this->deactivate()) {return ERROR;}
   if (!robot_manager_->isConnected()) {
     RCLCPP_ERROR(get_logger(), "not connected");
     return ERROR;

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -24,7 +24,7 @@ namespace kuka_sunrise
 {
 
 RobotManagerNode::RobotManagerNode()
-: LifecycleNode("robot_manager")
+: kroshu_ros2_core::ROS2BaseLCNode("robot_manager")
 {
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
   robot_manager_ = std::make_shared<RobotManager>(

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -19,7 +19,6 @@
 #include "kuka_sunrise/robot_manager_node.hpp"
 #include "kuka_sunrise/internal/service_tools.hpp"
 
-
 namespace kuka_sunrise
 {
 

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -60,16 +60,6 @@ RobotManagerNode::on_configure(const rclcpp_lifecycle::State &)
         this->shared_from_this()), robot_manager_);
   }
 
-  if (!this->has_parameter("controller_ip")) {
-    RCLCPP_ERROR(get_logger(), "Parameter controller_ip not available");
-    if (!requestRobotControlNodeStateTransition(
-        lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP))
-    {
-      RCLCPP_ERROR(get_logger(), "Could not solve differing states, restart needed");
-    }
-    return FAILURE;
-  }
-
   const char * controller_ip = this->get_parameter("controller_ip").as_string().c_str();
   if (!robot_manager_->isConnected()) {
     if (!robot_manager_->connect(controller_ip, 30000)) {
@@ -80,6 +70,9 @@ RobotManagerNode::on_configure(const rclcpp_lifecycle::State &)
         RCLCPP_ERROR(get_logger(), "Could not solve differing states, restart needed");
       }
       return FAILURE;
+    } else {
+      RCLCPP_ERROR(get_logger(), "Robot manager is connected in inactive state");
+      return ERROR;
     }
   }
   // TODO(resizoltan) get IO configuration
@@ -152,10 +145,6 @@ RobotManagerNode::on_activate(const rclcpp_lifecycle::State &)
     return ERROR;
   }
 
-  if (!this->has_parameter("send_period_ms") || !this->has_parameter("receive_multiplier")) {
-    RCLCPP_ERROR(get_logger(), "Parameter send_period_ms or receive_multiplier not available");
-    return FAILURE;
-  }
   int send_period_ms = this->get_parameter("send_period_ms").as_int();
   int receive_multiplier = this->get_parameter("receive_multiplier").as_int();
 

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -70,10 +70,10 @@ RobotManagerNode::on_configure(const rclcpp_lifecycle::State &)
         RCLCPP_ERROR(get_logger(), "Could not solve differing states, restart needed");
       }
       return FAILURE;
-    } else {
-      RCLCPP_ERROR(get_logger(), "Robot manager is connected in inactive state");
-      return ERROR;
     }
+  } else {
+    RCLCPP_ERROR(get_logger(), "Robot manager is connected in inactive state");
+    return ERROR;
   }
   // TODO(resizoltan) get IO configuration
 
@@ -172,8 +172,8 @@ RobotManagerNode::on_activate(const rclcpp_lifecycle::State &)
     return FAILURE;
   }
 
-  if (!this->activate()) {return FAILURE;}
   command_state_changed_publisher_->on_activate();
+  if (!this->activate()) {return FAILURE;}
 
   return SUCCESS;
 }


### PR DESCRIPTION
I have changed nodes to inherit from _ROS2BaseLCNode_ for better parameter handling and to reduce code duplication.
Additionally, I modified the rollback of the _robot_manager_node_, so that if the parameter setting in the configuration fails, the nodes transition back to unconfigured.
Changes to the parameter handling:
- added check on IP validity
- the _on_configure_ callback first declares the _controller_ip_ parameter, than connects to the given IP
- if successfully connected, the _robot_manager_  sends a trigger request to declare the other parameters (some of which need connection to the FRI)
    - this way the parameter callback can be registered at first, and the FRI related parameters are declared and set after successful connection -> this is in accordance with the intended ROS2 parameter design 