### PR TITLE
add sched_param to the correct place

### DIFF
--- a/kuka_rox_hardware_interface/src/rox_control_node.cpp
+++ b/kuka_rox_hardware_interface/src/rox_control_node.cpp
@@ -39,7 +39,6 @@ int main(int argc, char ** argv)
 
 
   std::thread control_loop([controller_manager, &is_configured]() {
-
       struct sched_param param;
       param.sched_priority = 95;
       if (sched_setscheduler(0, SCHED_FIFO, &param) == -1) {

--- a/kuka_rox_hardware_interface/src/rox_control_node.cpp
+++ b/kuka_rox_hardware_interface/src/rox_control_node.cpp
@@ -37,17 +37,19 @@ int main(int argc, char ** argv)
       is_configured = msg->data;
     });
 
-  struct sched_param param;
-  param.sched_priority = 95;
-  if (sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
-    RCLCPP_ERROR(controller_manager->get_logger(), "setscheduler error");
-    RCLCPP_ERROR(controller_manager->get_logger(), strerror(errno));
-    RCLCPP_WARN(
-      controller_manager->get_logger(),
-      "You can use the driver but scheduler priority was not set");
-  }
 
   std::thread control_loop([controller_manager, &is_configured]() {
+
+      struct sched_param param;
+      param.sched_priority = 95;
+      if (sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
+        RCLCPP_ERROR(controller_manager->get_logger(), "setscheduler error");
+        RCLCPP_ERROR(controller_manager->get_logger(), strerror(errno));
+        RCLCPP_WARN(
+          controller_manager->get_logger(),
+          "You can use the driver but scheduler priority was not set");
+      }
+
       const rclcpp::Duration dt =
       rclcpp::Duration::from_seconds(1.0 / controller_manager->get_update_rate());
       std::chrono::milliseconds dt_ms {1000 / controller_manager->get_update_rate()};


### PR DESCRIPTION
Since the sched_setscheduler function is called in the main, the executor is also spinning on RT priority, which is entirely pointless (especially since it's blocking). This PR solves this by calling the function inside the control_loop thread, where the meaningful stuff happens.